### PR TITLE
Build/PHPCS: use PHPCompatibilityWP and minor ruleset tweak

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -13,9 +13,10 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	
 	<!-- Rules -->
-	<rule ref="WordPress">
+	<rule ref="WordPress"/>
+	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>
-			<property name="additionalWordDelimiters" value="/" />
+			<property name="additionalWordDelimiters" value="/"/>
 		</properties>
 	</rule>
 	<rule ref="PHPCompatibilityWP" />

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -18,7 +18,7 @@
 			<property name="additionalWordDelimiters" value="/" />
 		</properties>
 	</rule>
-	<rule ref="PHPCompatibility" />
+	<rule ref="PHPCompatibilityWP" />
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 	<rule ref="NeutronStandard.StrictTypes.RequireStrictTypes.StrictTypes" />
 	<rule ref="NeutronStandard.Functions.TypeHint.NoReturnType" />

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "phpcodesniffer-standard",
     "require": {
         "wp-coding-standards/wpcs": "^1.0",
-        "wimg/php-compatibility": "^8.2",
+        "phpcompatibility/phpcompatibility-wp": "^1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "automattic/phpcs-neutron-standard": "^1.5"
     },


### PR DESCRIPTION
## Commit Summary

### Build/PHPCS: use PHPCompatibilityWP

* Switches the repo over to use `PHPCompatibilityWP` rather than `PHPCompatibility`.
    As this repo and ruleset appears to be aimed at WordPress projects, using the `PHPCompatibilityWP` ruleset is the better choice to prevent false positives for PHP functions and constants which are back-filled by WP.
* Switches the dependency over to use the repo in the `PHPCompatibility` organisation rather than the one in `wimg`'s personal account.

#### References:
* https://github.com/PHPCompatibility/PHPCompatibilityWP
* PHPCompatibility/PHPCompatibility#688
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0

### PHPCS Ruleset: minor fix

Properties belong to individual sniffs, not to standards. The way the property was set, it was going to be ignored. This minor changes fixes that.

#### References:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-word-delimiters-in-hook-names