### PR TITLE
Allow assets without a version number

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -13,7 +13,9 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	
 	<!-- Rules -->
-	<rule ref="WordPress"/>
+	<rule ref="WordPress">
+		<exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion" />
+	</rule>
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>
 			<property name="additionalWordDelimiters" value="/" />


### PR DESCRIPTION
WPCS 1.0 require the version argument to be filled in on enqueues, but we add a hash to the filename on our assets. This means we don’t need a version.

Lets exclude this rule from our coding standards.