### PR TITLE
Revert functions rules

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -13,7 +13,11 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	
 	<!-- Rules -->
-	<rule ref="WordPress"/>
+	<rule ref="WordPress">
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
+	</rule>
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>
 			<property name="additionalWordDelimiters" value="/" />


### PR DESCRIPTION
Think we should exclude a few more of the new rules in the WPCS 1.0. Don’t think these new rules make any sense and makes some of the code harder to read.

Excluding `PEAR.Functions.FunctionCallSignature.MultipleArguments` allows us to have arguments and ex. a array like this:
```
register_taxonomy( 'taxonomy-type, 'post-type', [
	…options
] );
```

Excluding `PEAR.Functions.FunctionCallSignature.CloseBracketLine|ContentAfterOpenBracket` allows us to add arrays like this in a function.
```
acf_add_options_page( [
	…options
] );
```