### PR TITLE
Exclude Generic.Arrays.DisallowShortArraySyntax

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -1,36 +1,37 @@
 <?xml version="1.0"?>
 <ruleset name="Dekode">
 	<description>Dekode Coding Standards</description>
-	
+
 	<!-- Arguments: colors, show progress and show sniff name. -->
 	<arg name="colors" />
 	<arg value="ps" />
-	
+
 	<!-- Exclude files -->
 	<exclude-pattern>wp/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>*content/plugins/</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	
+
 	<!-- Rules -->
 	<rule ref="WordPress">
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 	</rule>
-	
+
 	<rule ref="WordPress.NamingConventions.ValidHookName">
 		<properties>
 			<property name="additionalWordDelimiters" value="/" />
 		</properties>
 	</rule>
-	
+
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<properties>
 			<property name="exclude" value="file_get_contents" />
 		</properties>
 	</rule>
-	
+
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 	<rule ref="NeutronStandard.StrictTypes.RequireStrictTypes.StrictTypes" />


### PR DESCRIPTION
Closes #12 

Exclude Generic.Arrays.DisallowShortArraySyntax introduced in [WPCS 2.2](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.2.0).

Read more: https://github.com/WordPress/WordPress-Coding-Standards/pull/1770