### PR TITLE
Don’t exclude plugins in ruleset

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -9,7 +9,6 @@
 	<!-- Exclude files -->
 	<exclude-pattern>wp/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
-	<exclude-pattern>*content/plugins/</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 
 	<!-- Rules -->


### PR DESCRIPTION
In some projects we have custom made plugins in the repo. Excluding plugins in this ruleset prevent these plugins from beeing linted.

Also, plugins are excluded in the teft-theme ruleset anyways.