### PR TITLE
Ignore build and public/content

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -10,6 +10,8 @@
 	<exclude-pattern>wp/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>build/</exclude-pattern>
+	<exclude-pattern>public/content</exclude-pattern>
 
 	<!-- Rules -->
 	<rule ref="WordPress">


### PR DESCRIPTION
Might as well ignore these folders by default instead of having the ignore rule in every project(?)