### PR TITLE
Add phpcodesniffer-composer-installer to allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
 	"license": "MIT",
 	"archive": {
 		"exclude": [ "/packages" ]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
Fixes this notice:
```
❯ composer validate
dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
./composer.json is valid
```