### PR TITLE
Remove inactive Neutron PHP Standard

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -36,7 +36,4 @@
 
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
-	<rule ref="NeutronStandard.StrictTypes.RequireStrictTypes.StrictTypes" />
-	<rule ref="NeutronStandard.Functions.TypeHint.NoReturnType" />
-	<rule ref="NeutronStandard.Functions.TypeHint.NoArgumentType" />
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "dekode/coding-standards",
 	"description": "Dekode Coding Standards",
+	"license": "MIT",
 	"type": "phpcodesniffer-standard",
 	"keywords": [
 		"phpcs",
@@ -16,12 +17,14 @@
 		"DekodeInteraktiv"
 	],
 	"require": {
-		"wp-coding-standards/wpcs": "~2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"squizlabs/php_codesniffer": "~3.7.1"
+		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
+		"squizlabs/php_codesniffer": "~3.7.1",
+		"wp-coding-standards/wpcs": "~2.3.0"
 	},
-	"license": "MIT",
+	"require-dev": {
+		"ergebnis/composer-normalize": "^2.29"
+	},
 	"archive": {
 		"exclude": [
 			"/packages"
@@ -29,7 +32,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"ergebnis/composer-normalize": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
 	"require": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"squizlabs/php_codesniffer": "~3.7.1",
 		"wp-coding-standards/wpcs": "~2.3.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,27 +3,29 @@
 	"description": "Dekode Coding Standards",
 	"type": "phpcodesniffer-standard",
 	"keywords": [
-        "phpcs",
-        "standards",
-        "static analysis",
-        "code standards",
-        "code style",
-        "coding standards",
-        "coding style",
-        "PHP standards",
-        "WordPress",
-        "WordPress standards",
-        "DekodeInteraktiv"
-    ],
+		"phpcs",
+		"standards",
+		"static analysis",
+		"code standards",
+		"code style",
+		"coding standards",
+		"coding style",
+		"PHP standards",
+		"WordPress",
+		"WordPress standards",
+		"DekodeInteraktiv"
+	],
 	"require": {
-		"wp-coding-standards/wpcs": "^2.3",
-		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"wp-coding-standards/wpcs": "~2.3.0",
+		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"automattic/phpcs-neutron-standard": "^1.6"
+		"squizlabs/php_codesniffer": "~3.7.1"
 	},
 	"license": "MIT",
 	"archive": {
-		"exclude": [ "/packages" ]
+		"exclude": [
+			"/packages"
+		]
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
The Neutron PHP Standard is [no longer actively developed](https://github.com/Automattic/phpcs-neutron-standard#neutron-php-standard-).
This is more in line with default WordPress. We need to adjust and test our rules before this can be merged.