### PR TITLE
Keep up with WPCS `develop`

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -12,7 +12,6 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>build/</exclude-pattern>
 	<exclude-pattern>dist/</exclude-pattern>
-	<exclude-pattern>public/content</exclude-pattern>
 	<exclude-pattern>uploads/</exclude-pattern>
 
 	<!-- Rules -->

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -12,6 +12,7 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>build/</exclude-pattern>
 	<exclude-pattern>dist/</exclude-pattern>
+	<exclude-pattern>public/content</exclude-pattern>
 	<exclude-pattern>uploads/</exclude-pattern>
 
 	<!-- Rules -->

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -7,13 +7,13 @@
 	<arg value="ps" />
 
 	<!-- Exclude files -->
-	<exclude-pattern>build</exclude-pattern>
-	<exclude-pattern>dist</exclude-pattern>
-	<exclude-pattern>node_modules</exclude-pattern>
+	<exclude-pattern>wp/</exclude-pattern>
+	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>build/</exclude-pattern>
+	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>public/content</exclude-pattern>
-	<exclude-pattern>uploads</exclude-pattern>
-	<exclude-pattern>vendor</exclude-pattern>
-	<exclude-pattern>wp</exclude-pattern>
+	<exclude-pattern>uploads/</exclude-pattern>
 
 	<!-- Rules -->
 	<rule ref="WordPress">

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -13,7 +13,6 @@
 	<exclude-pattern>build/</exclude-pattern>
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>public/content</exclude-pattern>
-	<exclude-pattern>uploads/</exclude-pattern>
 
 	<!-- Rules -->
 	<rule ref="WordPress">

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -16,12 +16,13 @@
 
 	<!-- Rules -->
 	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.ValidHookName">

--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -7,11 +7,13 @@
 	<arg value="ps" />
 
 	<!-- Exclude files -->
-	<exclude-pattern>wp/</exclude-pattern>
-	<exclude-pattern>vendor/</exclude-pattern>
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>build/</exclude-pattern>
+	<exclude-pattern>build</exclude-pattern>
+	<exclude-pattern>dist</exclude-pattern>
+	<exclude-pattern>node_modules</exclude-pattern>
 	<exclude-pattern>public/content</exclude-pattern>
+	<exclude-pattern>uploads</exclude-pattern>
+	<exclude-pattern>vendor</exclude-pattern>
+	<exclude-pattern>wp</exclude-pattern>
 
 	<!-- Rules -->
 	<rule ref="WordPress">
@@ -20,6 +22,7 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.ValidHookName">

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
 	"require": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"wp-coding-standards/wpcs": "~2.3.0"
+		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "^2.29"
 	},
+	"minimum-stability": "dev",
 	"archive": {
 		"exclude": [
 			"/packages"


### PR DESCRIPTION
[WPCS](https://github.com/WordPress/WordPress-Coding-Standards) is being actively developed but they're not creating new releases to avoid the PHP8 issues in WordPress core. We suggest Dekode keeps track of the latest commits in `develop`, especially now that the [Neutron Standard](https://github.com/Automattic/phpcs-neutron-standard) is no longer maintained.

Correspond with this PR in Project Base: https://github.com/DekodeInteraktiv/project-base/pull/429