### PR TITLE
Upgrade to WPCS 3

### DIFF
--- a/Dekode/ruleset.xml
+++ b/Dekode/ruleset.xml
@@ -16,13 +16,11 @@
 
 	<!-- Rules -->
 	<rule ref="WordPress">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.ValidHookName">

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,11 @@
 	],
 	"require": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"ergebnis/composer-normalize": "~2.28.3",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"wp-coding-standards/wpcs": "^3.0"
+	},
+	"require-dev": {
+		"ergebnis/composer-normalize": "~2.28.3"
 	},
 	"archive": {
 		"exclude": [
@@ -29,8 +31,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"ergebnis/composer-normalize": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"ergebnis/composer-normalize": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"wp-coding-standards/wpcs": "^3.0"
 	},
 	"require-dev": {
-		"ergebnis/composer-normalize": "~2.28.3"
+		"ergebnis/composer-normalize": "^2.29"
 	},
 	"archive": {
 		"exclude": [

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 		"DekodeInteraktiv"
 	],
 	"require": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"ergebnis/composer-normalize": "~2.28.3",
-		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+		"wp-coding-standards/wpcs": "^3.0"
 	},
 	"archive": {
 		"exclude": [

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,12 @@
 		"WordPress standards",
 		"DekodeInteraktiv"
 	],
-	"require": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"wp-coding-standards/wpcs": "dev-develop"
-	},
 	"require-dev": {
-		"ergebnis/composer-normalize": "^2.29"
+		"ergebnis/composer-normalize": "~2.28.3",
+		"wp-coding-standards/wpcs": "^3.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
 	},
-	"minimum-stability": "dev",
 	"archive": {
 		"exclude": [
 			"/packages"
@@ -32,8 +29,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"ergebnis/composer-normalize": true
+			"ergebnis/composer-normalize": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"WordPress standards",
 		"DekodeInteraktiv"
 	],
-	"require-dev": {
+	"require": {
 		"ergebnis/composer-normalize": "~2.28.3",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	],
 	"require": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpcompatibility/phpcompatibility-wp": "~2.1.4",
 		"wp-coding-standards/wpcs": "^3.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
- [X] Upgrade to [WPCS 3.0.0](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0)
- [X] Remove `minimum-stability: dev` added when we wanted to target the develop branch of wpcs
- [X] Tested successfully on new project with PHP 8.1
- [X] Tested successfully on older project with PHP 7.4

### Some new nice features to highlight:
- Warnings for unused method parameters with `Generic.CodeAnalysis.UnusedFunctionParameter.Found`
- Detect wrongful use of `current_user_can()` with `WordPress.WP.Capabilities.RoleFound`

### A few minor changes to the current ruleset that can easily be ignored per project if needed.
- No space before colon in function return type declaration (`PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon`)
- Expected 1 space after FUNCTION keyword (`Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction`)
